### PR TITLE
lodash upgraded to 4.17.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"repository": "izaakschroeder/option-multiplexer",
 	"dependencies": {
 		"cartesian-product": "^2.1.2",
-		"lodash": "^3.8.0"
+		"lodash": "^4.17.11"
 	},
 	"devDependencies": {
 		"eslint": "^0.20.0",


### PR DESCRIPTION
lodash versions 4.17.4 and lower are vulnerable to Prototype Pollution. See https://nodesecurity.io/advisories/577