### PR TITLE
lodash upgraded to 4.17.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"repository": "izaakschroeder/option-multiplexer",
 	"dependencies": {
 		"cartesian-product": "^2.1.2",
-		"lodash": "^4.17.11"
+		"lodash": "^4.17.15"
 	},
 	"devDependencies": {
 		"eslint": "^0.20.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"repository": "izaakschroeder/option-multiplexer",
 	"dependencies": {
 		"cartesian-product": "^2.1.2",
-		"lodash": "^3.8.0"
+		"lodash": "^4.17.11"
 	},
 	"devDependencies": {
 		"eslint": "^0.20.0",


### PR DESCRIPTION
PR #1 changes Lodash version to 4.17.11 where the following vulnerability issue was fixed: https://nodesecurity.io/advisories/577.

Though Lodash **still remained vulnerable** to Prototype Pollution until 4.17.12. Please see:
https://www.npmjs.com/advisories/1065

This PR updates to the latest Lodash version and fixes the latter vulnerability.